### PR TITLE
You need to hook into both luastates at once.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ A compiled version of detours is included, and all terms of the included Microso
 	* Joel Juvél
 	* PlayYou
 	* and others who haven't been added yet
+	 


### PR DESCRIPTION
The VR lua layer is a different lua layer than the flatscreen layer. I noticed your code will check which layer it starts with/finds first and initalizes based on that.

The game defaults to the non-VR mode then turns on the VR mode, so you'll need to hook into both states at the start.

I'd file this as an issue but I can't because no issues enabled on the repo.